### PR TITLE
fix tags and hostname conf swap

### DIFF
--- a/rootfs/opt/rancher/entrypoint-wrapper.py
+++ b/rootfs/opt/rancher/entrypoint-wrapper.py
@@ -107,10 +107,10 @@ def main():
 	# TODO: set to environment instead of rewriting datadog.conf. Depends on DD Alpine image bug fix.
 	if host_tags:
 		host_tags_str = ", ".join(['%s:%s' % (key, value) for (key, value) in host_tags.items()])
-		replace_conf_agent["#tags:.*$"] = "tags: %s" % host_tags_str
+		replace_conf_agent["# tags:.*$"] = "tags: %s" % host_tags_str
 
 	if hostname:
-		replace_conf_agent["#hostname:.*$"] = "hostname: %s" % hostname
+		replace_conf_agent["# hostname:.*$"] = "hostname: %s" % hostname
 
 	print "Hostname: %s" % hostname
 	print "Exporting host labels as host tags:"


### PR DESCRIPTION
Datadog agent conf file has changed, there is now a space in between the comment and the variable, so this script will not fully work for new versions of the agent for swapping the conf's hostname and tags.

This resolves #3 